### PR TITLE
Avoiding null ref if user not logged in.

### DIFF
--- a/falcon-ui/src/main/java/org/calontir/marshallate/falcon/client/ui/SearchBar.java
+++ b/falcon-ui/src/main/java/org/calontir/marshallate/falcon/client/ui/SearchBar.java
@@ -184,16 +184,25 @@ public class SearchBar extends Composite implements DataUpdatedEventHandler, Sea
             groupBox.getElement().getStyle().setDisplay(Style.Display.INLINE);
             searchBox.getElement().getStyle().setDisplay(Style.Display.NONE);
             submit.getElement().getStyle().setDisplay(Style.Display.NONE);
-            ScaGroup scaGroup = LookupController.getInstance().getScaGroup(security.getLoginInfo().getGroup());
+
             logger.info("switchSearchType: group");
 
-            for (int i = 0; i < groupBox.getItemCount(); ++i) {
-                if (groupBox.getItemText(i).equals(scaGroup.getGroupName())) {
-                    groupBox.setItemSelected(i, true);
-                } else {
-                    groupBox.setItemSelected(i, false);
+            ScaGroup scaGroup = null;
+            if (security.isLoggedIn()) {
+                scaGroup = LookupController.getInstance().getScaGroup(security.getLoginInfo().getGroup());
+
+                for (int i = 0; i < groupBox.getItemCount(); ++i) {
+                    if (groupBox.getItemText(i).equals(scaGroup.getGroupName())) {
+                        groupBox.setItemSelected(i, true);
+                    } else {
+                        groupBox.setItemSelected(i, false);
+                    }
                 }
+            } else {
+                groupBox.setSelectedIndex(0);
+                scaGroup = LookupController.getInstance().getScaGroup(group.getValue(group.getSelectedIndex()));
             }
+
             fireEvent(new SearchEvent(scaGroup));
         }
     }


### PR DESCRIPTION
I encountered an error when clicking on the "group" radio button on the main page's search while not logged in. Once logged in, it works.

This change makes sure a group is passed to the search event, even when the user is not logged in. I originally considered having the switchSearchType method simply return early if the user was not logged in, but on the off-chance that the first group in the list is the one the user wanted to search for, they would have to change the dropdown to another value then change it back for the search they wanted to fire. When logged in and you select the "fighter" radio button, it immediately searches for all fighters, so having the selection of the "group" radio button also trigger a search seemed more consistent.

At present one can successfully search by a fighter's name without being logged in; this change matches that behaviour with the groups. If searching shouldn't be allowed prior to login, a different set of changes would be more appropriate.
